### PR TITLE
feat: get route info function

### DIFF
--- a/home/App.tsx
+++ b/home/App.tsx
@@ -17,6 +17,7 @@ const App = () => {
       <Home />
       <Element />
       <DynamicRoute />
+      <RouteInfo />
     </>
   )
 }

--- a/home/App.tsx
+++ b/home/App.tsx
@@ -3,6 +3,7 @@ import GlobalStyle from './components/GlobalStyle';
 import Home from "./Home";
 import DynamicRoute from "./DynamicRoute";
 import Element from "./Element";
+import RouteInfo from './RouteInfo'
 
 declare global {
   interface Window {

--- a/home/DynamicRoute.tsx
+++ b/home/DynamicRoute.tsx
@@ -69,6 +69,7 @@ const DynamicRoute = () => {
           {code}
         </SyntaxHighlighter>
       </div>
+      <ScrollDown href="#section-info" />
     </SDynamicRoute>
   )
 }

--- a/home/DynamicRoute.tsx
+++ b/home/DynamicRoute.tsx
@@ -5,6 +5,7 @@ import {githubGist} from "react-syntax-highlighter/dist/esm/styles/hljs";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import Section from "./components/Section";
 import {Radio, RadioGroup} from "./components/Radio";
+import ScrollDown from './components/ScrollDown'
 
 const SDynamicRoute = styled(Section)`
   display: flex;

--- a/home/RouteInfo.tsx
+++ b/home/RouteInfo.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useCallback, useEffect } from "react";
+import styled from "styled-components";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { githubGist } from "react-syntax-highlighter/dist/esm/styles/hljs";
+import SMapProvider from "../src/SMapProvider";
+import Section from "./components/Section";
+import { getRouteInfo, RouteInfoResultProps } from "../src/helperFunctions";
+
+const SRouteInfo = styled(Section)`
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+`;
+
+const code = `
+  const [routeInfo, setRouteInfo] = useState<null | RouteInfoProps>(null);
+
+  const fetchRouteInfo = useCallback(async () => {
+    const info = await getRouteInfo([
+      { lat: 49.5329453, lng: 18.5110686 },
+      { lat: 49.5440406, lng: 18.4509133 },
+      { lat: 49.5457367, lng: 18.4479764 },
+    ], {
+      geometry: true,
+      itinerary: true,
+      altitude: true,
+      criterion: "turist2",
+    } as any);
+    setRouteInfo(info);
+  }, []);
+
+  useEffect(() => {
+    fetchRouteInfo();
+  }, []);
+`;
+
+const coords = [
+  { lat: 49.5329453, lng: 18.5110686 },
+  { lat: 49.5440406, lng: 18.4509133 },
+  { lat: 49.5457367, lng: 18.4479764 },
+];
+
+const params = {
+  geometry: true,
+  itinerary: true,
+  altitude: true,
+  criterion: "turist2",
+};
+
+const RouteInfo = () => {
+  const [routeInfo, setRouteInfo] = useState<null | RouteInfoResultProps>(null);
+
+  const fetchRouteInfo = useCallback(async () => {
+    const info = await getRouteInfo(coords, params as any);
+    setRouteInfo(info);
+  }, []);
+
+  useEffect(() => {
+    fetchRouteInfo();
+  }, []);
+
+  return (
+    <SRouteInfo id="section-info">
+      <div style={{ width: "40%" }}>
+        <SyntaxHighlighter
+          language="javascript"
+          wrapLongLines={true}
+          style={githubGist}
+        >
+          {code}
+        </SyntaxHighlighter>
+      </div>
+      <div style={{ width: "50%" }}>
+        <h1>Route info</h1>
+        Get basic information about your route.
+        <h2>Available data:</h2>
+        <p>Id: {routeInfo?.id!}</p>
+        <p>Descent: {routeInfo?.descent!} [m]</p>
+        <p>Ascent: {routeInfo?.ascent!} [m]</p>
+        <p>
+          In Europe (not in Czech republic): {routeInfo?.inEurope!.toString()}
+        </p>
+        <p>Length: {routeInfo?.length!} [m]</p>
+        <p>Time: {routeInfo?.time!} [s]</p>
+        <p>URL:</p>{" "}
+        <a href={routeInfo?.url!} target="_blank">
+          {routeInfo?.url!}
+        </a>
+      </div>
+    </SRouteInfo>
+  );
+};
+
+export default SMapProvider(RouteInfo);

--- a/src/helperFunctions.ts
+++ b/src/helperFunctions.ts
@@ -1,0 +1,34 @@
+interface Results {
+  [key:string]: any;
+}
+
+interface RouteProps {
+  geometry?: boolean,
+  itinerary?: boolean,
+  altitude?: boolean,
+  criterion: 'fast' | 'short' | 'bike1' | 'bike2' | 'bike3' | 'turist1' | 'turist2'
+}
+
+export type RouteInfoResultProps = {
+  altitude: number[];
+  ascent: number;
+  descent: number;
+  geometry: any[];
+  id: string;
+  inEurope: boolean;
+  points: object[];
+  length: number;
+  time: number;
+  url: string;
+};
+
+const getDynamicPath = (results: Results) => {
+  const routeInfo = results && results.getResults();
+  return routeInfo;
+}
+               
+export const getRouteInfo = async (coords:  Array<{ lng: number, lat: number }>, params: RouteProps) => {
+  const routePoints = coords.map(p => window.SMap.Coords.fromWGS84(p.lng, p.lat));
+
+  return window.SMap.Route.route(routePoints, params).then(getDynamicPath);
+}


### PR DESCRIPTION
This PR implements a helper function for getting route info.

**How to use:**
1. Import a helper function (and route info props):
```
import { getRouteInfo, RouteInfoResultProps } from "../src/helperFunctions";
```

2. Set `useState` hook for data from mapy.cz API:
```
const [routeInfo, setRouteInfo] = useState<null | RouteInfoResultProps>(null);
```

3. Call the helper function:
```
const fetchRouteInfo = useCallback(async () => {
  const info = await getRouteInfo(coords, params as any);
  setRouteInfo(info);
}, []);
```

4. Don't forget set `useEffect` function:
```
useEffect(() => {
  fetchRouteInfo();
}, []);
```

5. Tada. 🎉  Route info is set in `routeInfo` const and you can use it now.

⚠️ **CI issues:**
I'm getting some CI issues here at GitHub. When I tried run `npm run predeploy` locally, I'm not getting any error (I'm locally using the same version of npm and nodejs). Honestly, I don't understand the error message from codeclimate, I've noticed that other functions in this project have more lines than mine and they pass ok. Could you take a look at it, please? 🙏 