### PR TITLE
Bugfix - marker recreation on change of props

### DIFF
--- a/src/Marker.tsx
+++ b/src/Marker.tsx
@@ -69,7 +69,7 @@ const Marker = (props: MarkerProps) => {
         return () => {
             markerLayer.removeMarker(sMarker, true);
         };
-    }, []);
+    }, [markerLayer, props.card, sMarker]);
 
     return null;
 };


### PR DESCRIPTION
closes flsy/react-mapycz#489